### PR TITLE
Document required secrets and guard map rendering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Authentication secret used by NextAuth.js
+# Generate a long random string for production deployments.
+# You can alternatively set NEXTAUTH_SECRET if you prefer the legacy name.
+AUTH_SECRET=replace-with-strong-random-string
+
+# Public Mapbox access token used by the interactive map component.
+# This token must allow requests from your deployed domain.
+NEXT_PUBLIC_MAPBOX_TOKEN=pk.your-mapbox-public-token

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+## Environment configuration
+
+Copy the provided `.env.example` file to `.env.local` and fill in the required values before running the application:
+
+```
+cp .env.example .env.local
+```
+
+The project expects the following environment variables:
+
+- `AUTH_SECRET` (or `NEXTAUTH_SECRET`): a long random string used by NextAuth.js to sign cookies and JSON Web Tokens. This **must** be configured in production (e.g. Vercel) to avoid the `GET /api/auth/error 500` configuration error.
+- `NEXT_PUBLIC_MAPBOX_TOKEN`: a public Mapbox access token used to render the interactive map. Make sure the token allows requests from your deployed domain.
+
+After updating the `.env.local` file you can run the development server:
 
 ```bash
 npm run dev

--- a/src/app/api/auth/[...nextauth]/route.js
+++ b/src/app/api/auth/[...nextauth]/route.js
@@ -1,6 +1,17 @@
 import NextAuth from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 
+const authSecret =
+  process.env.AUTH_SECRET ??
+  process.env.NEXTAUTH_SECRET ??
+  (process.env.NODE_ENV === "development" ? "dev-nextauth-secret" : undefined);
+
+if (!authSecret) {
+  throw new Error(
+    "Missing AUTH_SECRET (or NEXTAUTH_SECRET). Set it in your environment variables before deploying."
+  );
+}
+
 export const authOptions = {
   providers: [
     CredentialsProvider({
@@ -25,6 +36,7 @@ export const authOptions = {
   session: {
     strategy: "jwt"
   },
+  secret: authSecret,
   pages: {
     signIn: "/auth/signin"
   }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -21,6 +21,31 @@ export default function MapboxMap({ initialView = DEFAULT_VIEW, pins = demoPins 
   const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
   const [popupInfo, setPopupInfo] = useState(null);
 
+  if (!token) {
+    return (
+      <Box
+        sx={{
+          height: '100%',
+          minHeight: 400,
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          p: 3,
+          bgcolor: 'background.paper'
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Map rendering is disabled because the <code>NEXT_PUBLIC_MAPBOX_TOKEN</code> environment variable is not
+          configured. Add a Mapbox public access token in your deployment settings to display the interactive map.
+        </Typography>
+      </Box>
+    );
+  }
+
   const mapStyle = useMemo(
     () => 'mapbox://styles/mapbox/streets-v12',
     []


### PR DESCRIPTION
## Summary
- ensure NextAuth is configured with a server secret and fail fast when it is missing
- add a helpful fallback UI when the Mapbox token is not configured
- document required environment variables and provide an `.env.example`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a0d7293c832c836ad5e522757096